### PR TITLE
docs(readme): add CI status badges for markdownlint and PR template check

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
 ![Lab Status](https://img.shields.io/badge/lab--status-in_progress-orange)
 
+[![markdownlint](https://github.com/iplaycomputer/hybrid-ad-azure-lab/actions/workflows/markdownlint.yml/badge.svg?branch=main)](https://github.com/iplaycomputer/hybrid-ad-azure-lab/actions/workflows/markdownlint.yml)
+[![PR template check](https://github.com/iplaycomputer/hybrid-ad-azure-lab/actions/workflows/pr-template-check.yml/badge.svg?branch=main)](https://github.com/iplaycomputer/hybrid-ad-azure-lab/actions/workflows/pr-template-check.yml)
+
 ## Table of Contents
 
 1. [Lab Purpose & Audience](#lab-purpose--audience)


### PR DESCRIPTION
# Summary

Add CI status badges for markdownlint and PR template check to README.

## Changes

- Scripts:
  - [ ] New/updated PowerShell (list files)
- Docs:
  - [x] README/Overview changes
- Infra:
  - [ ] Terraform or other infra updates
- Tooling/CI:
  - [ ] Linting/workflows/editor configs

## Labs affected (if any)

- N/A

## Testing & validation

- Docs
  - [x] Markdownlint passes locally (npm run lint:md)
  - [x] Badge links resolve to workflow pages

## Checklist

- [x] No credentials, personal IPs, or tenant IDs committed
- [x] README updated (badges added)

## How to verify (for reviewers)

- Open README; confirm badges render and link to the correct workflows on branch=main.

## Backout plan

- Revert this PR.
