### PR TITLE
docs: add CONTRIBUTING.md and link from README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+# Contributing
+
+Thanks for your interest in contributing to this Hybrid AD / Azure AD / O365 lab. This project uses pull requests to keep `main` stable and visible. Please follow the process below.
+
+## Pull request process
+
+- Fork or create a topic branch from `main`.
+- Keep changes focused and small; one logical change per PR.
+- Use the repository PR template (auto-included when you open a PR) and complete all required sections.
+- Ensure required checks are passing before requesting merge.
+- Squash-merge is the preferred merge strategy; the repository enforces a linear history.
+
+## Required checks
+
+These must be green on each PR:
+
+- markdownlint: Lints all Markdown files using markdownlint-cli2.
+- PR template check: Verifies the PR body contains all required sections.
+
+## Local verification
+
+Run these locally before pushing to reduce CI churn.
+
+### Markdown
+
+```powershell
+# From the repo root
+npm ci
+npm run lint:md
+```
+
+### PowerShell syntax (scripts/)
+
+```powershell
+# Syntax check all scripts
+Get-ChildItem -Path scripts -Filter *.ps1 -Recurse | ForEach-Object { ./scripts/tools/parse-check.ps1 -Path $_.FullName }
+
+# Or check a single file
+./scripts/tools/parse-check.ps1 -Path ./scripts/sample-setup.ps1
+```
+
+## Commit messages
+
+- Use concise, conventional prefixes when helpful (e.g., docs:, chore:, feat:, fix:).
+- Examples:
+  - `docs(readme): add CI badges`
+  - `chore(tools): improve parse-check error message`
+
+## Scope and guardrails
+
+- Focus on hybrid identity core first; advanced or adjacent topics can be proposed as optional extensions.
+- No credentials, personal IPs, or tenant IDs should be committed. Use placeholders like `<tenant-name>`, `<vm-ip>`.
+
+## Questions
+
+Open an issue with your proposal or question, or start a draft PR if you prefer code to discuss.

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ To practice:
 
 ## Contributing
 
-Contributions are welcome. This repo enforces pull requests to `main` with required checks.
+Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for details. This repo enforces pull requests to `main` with required checks.
 
 - Required checks on PRs: markdownlint and “PR template check” must pass.
 - Please follow the PR template: see `.github/pull_request_template.md`.


### PR DESCRIPTION
# Summary

Add a CONTRIBUTING.md to document the PR process, required checks, and local verification commands; link it from README to improve discoverability.

## Changes

- Docs:
  - [x] README/Overview changes (link to CONTRIBUTING.md)
  - [x] New/updated lab docs (CONTRIBUTING.md)
- Tooling/CI:
  - [x] Linting/workflows/editor configs (no changes; verified lint)

## Labs affected (if any)

- N/A

## Testing & validation

- Docs
  - [x] Markdownlint passes locally (npm run lint:md)
  - [x] Links resolve in repo preview
- Scripts
  - [x] parse-check.ps1 guidance included; no script changes

## Checklist

- [x] No credentials, personal IPs, or tenant IDs committed
- [x] PR template used with required sections
- [x] README updated if new docs/scripts were added

## How to verify (for reviewers)

- Open README and confirm “Contributing” links to CONTRIBUTING.md.
- Open CONTRIBUTING.md and skim sections for PR flow, checks, and local commands.
- Confirm CI markdownlint status is green.

## Backout plan

- Revert this PR.